### PR TITLE
Version fix

### DIFF
--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -1,10 +1,12 @@
+.. include:: quick_docs_common.rst
+
 Citation
 ========
 
-  Please cite QUICK-22.03 as follows. 
+  Please cite |QUICK_VERSION| as follows. 
 
   Manathunga, M.; Shajan, A.; Giese, T. J.; Cruzeiro, V. W. D.; Smith, J.; Miao, Y.; He, X.; Ayers,K;
-  Brothers, E.; Götz, A. W.; Merz, K. M. QUICK-22.03 University of California San Diego, CA and Michigan State University, East Lansing, MI, 2022.
+  Brothers, E.; Götz, A. W.; Merz, K. M. |QUICK_VERSION| University of California San Diego, CA and Michigan State University, East Lansing, MI, 2022.
 
   Publications to date:
 

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -1,7 +1,9 @@
 .. Keep this file up to date with index.rst file. 
 
-Welcome to QUICK-22.03 Documentation!
-======================================
+.. include:: quick_docs_common.rst
+
+Welcome to |QUICK_VERSION| Documentation!
+===============================================
 
 .. toctree::
    :maxdepth: 2
@@ -17,7 +19,6 @@ Welcome to QUICK-22.03 Documentation!
    developer-guide
    citation
    license
-
 
 **Note to Users:** QUICK is still in the experimental stage and we do not guarantee
 it will work flawlessly in all your applications. But we are working hard to detect

--- a/docs/source/developer-guide.rst
+++ b/docs/source/developer-guide.rst
@@ -1,3 +1,5 @@
+.. include:: quick_docs_common.rst
+
 Developer Guide
 ===============
 
@@ -455,9 +457,9 @@ You should update this table by adhering to the rules below.
 
  4. DO NOT CHANGE THE TABLE/COLUMN WIDTH! VERTICAL BORDERS MUST REMAIN THE SAME.
 
-Note 1: Current version of QUICK (v22.03) ERI engine only support basis functions up to *d*. Therefore, do not add high angular momentum basis sets and attempt to use f/g functions.
+Note 1: Current version of QUICK ERI engine only support basis functions up to *d*. Therefore, do not add high angular momentum basis sets and attempt to use f/g functions.
 
-Note 2: ECPs are not supported by QUICK-22.03. Therefore care must be taken not to add elements that require ECPs as this would lead to wrong results.
+Note 2: ECPs are not supported by |QUICK_VERSION|. Therefore care must be taken not to add elements that require ECPs as this would lead to wrong results.
 
 Adding new test cases into test suite
 -------------------------------------
@@ -479,7 +481,7 @@ Some example test case names that follow this convention are shown below.
  opt_wat_rhf_631g.in, opt_wat_rhf_631g.out
 
 Second, test list files located inside $QUICK_HOME/test should be updated. These are just .txt files that record names of test cases. 
-As of QUICK-22.03, there are 4 testlist files: testlist_short.txt, testlist_short_cuda.txt, testlist_full.txt, testlist_full_cuda.txt.
+Currently, there are 4 testlist files: testlist_short.txt, testlist_short_cuda.txt, testlist_full.txt, testlist_full_cuda.txt.
 The first and second contain short test lists that would be used for standard testing (i.e. by executing *make test* or *./runtest* commands) 
 of quick/quick.MPI and quick.cuda/quick.cuda.MPI executables. The third and fourth are used for robust testing (i.e. by executing *make fulltest* 
 or *./runtest - -full* commands) which usually happens during CI. 

--- a/docs/source/features-limitations.rst
+++ b/docs/source/features-limitations.rst
@@ -1,7 +1,9 @@
+.. include:: quick_docs_common.rst
+
 Features and Limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-QUICK-22.03 has the following features and limitations.
+|QUICK_VERSION| has the following features and limitations.
 
 Features
 ********

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,10 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to QUICK-22.03 Documentation!
-======================================
+.. include:: quick_docs_common.rst
+
+Welcome to |QUICK_VERSION| Documentation!
+=========================================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/installation-guide.rst
+++ b/docs/source/installation-guide.rst
@@ -1,5 +1,7 @@
+.. include:: quick_docs_common.rst
+
 Installation Guide
-========================
+==================
 
 QUICK has been compiled and tested on x86 and ARM CPU and Intel Nvidia GPU hardware.
 The compilation of the GPU enabled ERI code can take a significant amount of time (several minutes) - be patient, the compiler is working hard to generate lightning fast code for you.
@@ -8,7 +10,7 @@ Compatible Compilers and Hardware
 ---------------------------------
 
 In general QUICK works well with a range of GNU or Intel compilers, Intel MKL, Open MPI, Intel MPI, and different CUDA version. 
-We have specifically tested QUICK-22.03 with following compilers under the Linux operating system.
+We have specifically tested |QUICK_VERSION| with following compilers under the Linux operating system.
 
 • Serial version
 
@@ -33,7 +35,7 @@ We have specifically tested QUICK-22.03 with following compilers under the Linux
  2. GNU/9.3.0; CUDA/11.0.207; OPENMPI/4.0.3          : No issue detected so far.
  3. Intel/2018.1.163; Intelmpi/2018.1.163; CUDA/10.2 : No issue detected so far.
 
-QUICK-22.03 CUDA version has been tested on the following GPU cards: A100, RTX2080Ti, RTX8000, RTX6000, RTX2080, T4, V100, Titan V, P100, M40, GTX1080, K80 and K40.
+|QUICK_VERSION| CUDA version has been tested on the following GPU cards: A100, RTX2080Ti, RTX8000, RTX6000, RTX2080, T4, V100, Titan V, P100, M40, GTX1080, K80 and K40.
 
 **Note:** we recommend that the CUDA and CUDA-MPI versions be executed only on dedicated GPU cards where no other tasks are being run.
 For the CUDA-MPI version we also recommend that only one CPU per GPU is used; this can be done by setting the number of processes (*e.g.*,

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -1,7 +1,7 @@
 Known Issues of Current Version
 ===============================
 
-QUICK is under continous development and as of latest version, we have detected
+QUICK is under continous development and as of the latest version, we have detected
 the issues listed below. If you find anything other than these, please feel free to
 report any bugs or issues through our Git Hub page: `https://github.com/merzlab/QUICK/issues <https://github.com/merzlab/QUICK/issues>`_.
 

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -1,7 +1,7 @@
 Known Issues of Current Version
 ===============================
 
-QUICK is under continous development and as of version 22.03, we have detected
+QUICK is under continous development and as of latest version, we have detected
 the issues listed below. If you find anything other than these, please feel free to
 report any bugs or issues through our Git Hub page: `https://github.com/merzlab/QUICK/issues <https://github.com/merzlab/QUICK/issues>`_.
 

--- a/docs/source/quick_docs_common.rst
+++ b/docs/source/quick_docs_common.rst
@@ -1,0 +1,1 @@
+.. |QUICK_VERSION| replace:: QUICK

--- a/docs/source/quick_docs_common.rst
+++ b/docs/source/quick_docs_common.rst
@@ -1,1 +1,1 @@
-.. |QUICK_VERSION| replace:: QUICK
+.. |QUICK_VERSION| replace:: QUICK-development

--- a/docs/source/working_libxc_funcs.rst
+++ b/docs/source/working_libxc_funcs.rst
@@ -1,7 +1,9 @@
+.. include:: quick_docs_common.rst
+
 A List of Available DFT Functionals
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Based on our tests, following functionals are successully working in QUICK-22.03 serial, MPI, CUDA and CUDAMPI versions. 
+Based on our tests, following functionals are successully working in |QUICK_VERSION| serial, MPI, CUDA and CUDAMPI versions. 
 Note that here we are reporting LIBXC keywords that will be specified in QUICK input. `Please use LIBXC functionals page
 for more information on each keyword. <https://www.tddft.org/programs/libxc/functionals/previous/libxc-4.0.4/>`_. 
 


### PR DESCRIPTION
I have added QUICK_VERSION variable to facilitate setting QUICK version in the documentation. For a release version, we will have to set QUICK_VERSION value in quick_docs_common.rst to a string value (eg. QUICK-23.03). 