### PR TITLE
Links to older QUICK documentations

### DIFF
--- a/docs/source/all-quick-documentations.rst
+++ b/docs/source/all-quick-documentations.rst
@@ -1,0 +1,10 @@
+All QUICK documentation versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+• `QUICK-development <https://quick-docs.readthedocs.io/en/latest/>`_
+• `QUICK-22.03 <https://quick-docs.readthedocs.io/en/22.3.0/>`_ 
+• `QUICK-21.03 <https://quick-docs.readthedocs.io/en/21.3.0/>`_ 
+• `QUICK-20.06 <https://quick-docs.readthedocs.io/en/20.6.0/>`_ 
+• `QUICK-20.03 <https://quick-docs.readthedocs.io/en/20.3.0/>`_ 
+
+*Last updated by Madu Manathunga on 10/03/2022.*

--- a/docs/source/all-quick-documentations.rst
+++ b/docs/source/all-quick-documentations.rst
@@ -2,8 +2,8 @@ All QUICK documentation versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 • `QUICK-development <https://quick-docs.readthedocs.io/en/latest/>`_
-• `QUICK-22.03 <https://quick-docs.readthedocs.io/en/22.3.0/>`_ 
-• `QUICK-21.03 <https://quick-docs.readthedocs.io/en/21.3.0/>`_ 
+• `QUICK-22.03 <https://quick-docs.readthedocs.io/en/22.3.0/>`_ (also released with AmberTools22)
+• `QUICK-21.03 <https://quick-docs.readthedocs.io/en/21.3.0/>`_ (also released with AmberTools21)
 • `QUICK-20.06 <https://quick-docs.readthedocs.io/en/20.6.0/>`_ 
 • `QUICK-20.03 <https://quick-docs.readthedocs.io/en/20.3.0/>`_ 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022 Götz Lab & Merz Lab'
 author = 'Madu Manathunga'
 
 # The full version, including alpha/beta/rc tags
-release = '23.3.0'
+release = '22.3.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022 Götz Lab & Merz Lab'
 author = 'Madu Manathunga'
 
 # The full version, including alpha/beta/rc tags
-release = '22.3.0'
+release = '23.3.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022 Götz Lab & Merz Lab'
 author = 'Madu Manathunga'
 
 # The full version, including alpha/beta/rc tags
-release = '22.3.0'
+#release = '22.3.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -19,10 +19,11 @@ Welcome to |QUICK_VERSION| Documentation!
    developer-guide
    citation
    license
+   all-quick-documentations
 
 **Note to Users:** QUICK is still in the experimental stage and we do not guarantee
 it will work flawlessly in all your applications. But we are working hard to detect
 and fix issues. If you experience any compile or runtime issues, please report to us
 through our github repository: `<https://github.com/merzlab/QUICK/issues>`_.
 
-*Last updated by Madu Manathunga on 03/03/2022.*
+*Last updated by Madu Manathunga on 10/03/2022.*

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,12 +22,12 @@ Welcome to |QUICK_VERSION| Documentation!
    developer-guide
    citation
    license
-
+   all-quick-documentations
 
 **Note to Users:** QUICK is still in the experimental stage and we do not guarantee 
 it will work flawlessly in all your applications. But we are working hard to detect 
 and fix issues. If you experience any compile or runtime issues, please report to us 
 through our github repository: `<https://github.com/merzlab/QUICK/issues>`_. 
 
-*Last updated by Madu Manathunga on 03/03/2022.*
+*Last updated by Madu Manathunga on 10/03/2022.*
 


### PR DESCRIPTION
In this PR, I have added a new page to direct users to older versions of QUICK documentation. 