### PR TITLE
AWG - update QUICK documentation for QUICK-24.03 release

### DIFF
--- a/docs/source/all-quick-documentations.rst
+++ b/docs/source/all-quick-documentations.rst
@@ -9,4 +9,4 @@ All QUICK documentation versions
 • `QUICK-20.06 <https://quick-docs.readthedocs.io/en/20.6.0/>`_ 
 • `QUICK-20.03 <https://quick-docs.readthedocs.io/en/20.3.0/>`_ 
 
-*Last updated by Madu Manathunga on 10/03/2022.*
+*Last updated by Andy Goetz on 04/25/2024.*

--- a/docs/source/basis-sets.rst
+++ b/docs/source/basis-sets.rst
@@ -8,21 +8,32 @@
   6-311G 
   6-311G* or 6-311G(d)
   6-311G** or 6-311G(d,p)
+  6-311G(2df,2pd)
   6-31+G* or 6-31+G(d)
   6-31+G** or 6-31+G(d,p)
   6-31++G** or 6-31++G(d,p)
   6-311+G(2d,p)
   6-311++G(2d,2p)
   cc-pVDZ
+  cc-pVTZ
+  aug-cc-pVDZ
+  aug-cc-pVTZ
   def2-SV(P)
   def2-SVP
   def2-SVPD
+  def2-TZVP
+  def2-TZVPD
+  def2-TZVPP
+  def2-TZVPPD
   PC-0
   PC-1
+  PC-2
+  aug-PC-1
+  aug-PC-2
 
 Note 1: We follow the same basis set names reported at the `basis set exchange web page <https://www.basissetexchange.org/>`_. 
 
-Note 2: The current version of the QUICK ERI engine only support basis functions up to *d*. Therefore, energy and gradient calculations with functions up to *d* are possible.
+Note 2: The current version of the QUICK ERI engine only support basis functions up to *f*. Therefore, energy and gradient calculations with functions up to *f* are possible. By default, *f* functions are disabled in the GPU code. Open-shell gradient calculations with *f* functions are not yet available on GPU.
 
 Note 3: ECPs are currently not supported by QUICK. Due to this reason, we have excluded elements that require ECPs from the above basis sets that are included with QUICK.
 

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -3,16 +3,16 @@
 Citation
 ========
 
-Please cite |QUICK_VERSION| as follows. 
+**Please cite** |QUICK_VERSION| **as follows.**
 
-  Manathunga, M.; O'Hearn, K. A.; Shajan, A.; Giese, T. J.; Cruzeiro, V. W. D.; Smith, J.; Miao, Y.; He, X.; Ayers,K;
+  Manathunga, M.; O'Hearn, K. A.; Shajan, A.; Smith, J.; Miao, Y.; He, X.; Ayers, K;
   Brothers, E.; Götz, A. W.; Merz, K. M. |QUICK_VERSION| University of California San Diego, CA and Michigan State University, East Lansing, MI, 2024.
 
-If you perform density functional theory calculations please also cite:
+**If you perform density functional theory calculations** please cite:
 
   `Manathunga, M.; Miao, Y.; Mu, D.; Götz, A. W.; Merz, K. M. Parallel Implementation of Density Functional Theory Methods in the Quantum Interaction Computational Kernel Program. J. Chem. Theory Comput. 16, 4315–4326 (2020). <https://pubs.acs.org/doi/10.1021/acs.jctc.0c00290>`_
 
-If you use the GPU version please also cite:
+**If you use the GPU version** please also cite:
   
   `Manathunga, M.; Aktulga, H. M.; Götz, A. W.; Merz, K. M. Quantum Mechanics/Molecular Mechanics Simulations on NVIDIA and AMD Graphics Processing Units. J. Chem. Inf. Model. 63, 711-717 (2023). <https://pubs.acs.org/doi/10.1021/acs.jcim.2c01505>`_
 
@@ -20,17 +20,17 @@ If you use the GPU version please also cite:
 
   `Miao, Y.; Merz, K. M. Acceleration of Electron Repulsion Integral Evaluation on Graphics Processing Units via Use of Recurrence Relations. J. Chem. Theory Comput. 9, 965–976 (2013). <https://pubs.acs.org/doi/abs/10.1021/ct300754n>`_
 
-For multi-GPU calculations please also cite:
+**For multi-GPU calculations** please also cite:
 
   `Manathunga, M.; Jin, C; Cruzeiro, V. W. D.; Miao, Y.; Mu, D.; Arumugam, K.; Keipert, K.; Aktulga, H. M.; Merz, K. M.; Götz, A. W. Harnessing the Power of Multi-GPU Acceleration into the Quantum Interaction Computational Kernel Program, J. Chem. Theory Comput. 17, 3955–3966 (2021). <https://pubs.acs.org/doi/abs/10.1021/acs.jctc.1c00145>`_
 
-If you use QUICK in QM/MM simulations please also cite:
+**If you use QUICK in QM/MM simulations** please also cite:
   
   `Manathunga, M.; Aktulga, H. M.; Götz, A. W.; Merz, K. M. Quantum Mechanics/Molecular Mechanics Simulations on NVIDIA and AMD Graphics Processing Units. J. Chem. Inf. Model. 63, 711-717 (2023). <https://pubs.acs.org/doi/10.1021/acs.jcim.2c01505>`_
 
   `Cruzeiro, V. W. D.; Manathunga, M.; Merz,K. M.; Götz, A. W. Open-Source Multi-GPU-Accelerated QM/MM Simulations with AMBER and QUICK. J. Chem. Inf. Model. 61, 2109–2115 (2021) <https://pubs.acs.org/doi/abs/10.1021/acs.jcim.1c00169>`_.
 
-Please also cite relevant third-party software.
+**Please also cite relevant third-party software.**
 If you used Libxc (all DFT calculations except BLYP and B3LYP) please also cite:
 
   `Lehtola, S.; Steigemann, C.; Oliveira, M. J. T.; Marques, M. A. L. Recent developments in Libxc - A comprehensive library of functionals for density functional theory. Software X 2018, 7, 1 <http://dx.doi.org/10.1016/j.softx.2017.11.002>`_.
@@ -40,4 +40,4 @@ If you perform geometry optimization calculations using the DL-FIND optimizer (d
   `Kästner, J.; Carr, J. M.; Keal, T. W.; Thiel, W.; Wander, A.; Sherwood, P. DL-FIND: An Open-Source Geometry Optimizer for Atomistic Simulations. J. Phys. Chem. A 113, 11856-11865 (2009). <https://pubs.acs.org/doi/10.1021/jp9028968>`_
 
 
-*Last updated by Andy Goetz on 02/17/2023.*
+*Last updated by Andy Goetz on 04/25/2024.*

--- a/docs/source/features-limitations.rst
+++ b/docs/source/features-limitations.rst
@@ -19,17 +19,19 @@ Features
 • Supports QM/MM calculations with Amber22 and later
 • Fortran API to use QUICK as QM energy and force engine
 • Message Passing Interface (MPI) distributed parallelization for CPU platforms
-• Massively parallel, single GPU implementation via CUDA and HIP for Nvidia and AMD GPUs 
+• Massively parallel, single GPU implementation via CUDA and HIP for Nvidia and AMD GPUs (HIP available in QUICK-23.08, currently disabled)
 • Distributed, multi-GPU support via MPI+CUDA/MPI+HIP, also across multiple compute nodes
 
 Limitations
 ***********
 
-• Supports energy/gradient calculations with basis functions up to d (f function support available on CUDA versions)
-• HIP/MPI+HIP support disabled for this release due to GPU code rewrites (f basis function support), please use QUICK version 23.08b for HIP support
+• Supports energy/gradient calculations with basis functions up to f
+• GPU f function code is not highly optimized, requires large amount of RAM (may fail on consumer GPUs)
+• No open shell gradients with f functions on GPUs
 • Supports only Cartesian basis functions (no spherical harmonics)
 • Effective core potentials (ECPs) are not supported
 • DFT calculations are performed exclusively using the SG1 grid system
 • No meta-GGA nor range-separated hybrid functionals are supported at present
+• HIP/MPI+HIP support disabled for this release due to GPU code rewrites (f basis function support), please use QUICK version 23.08b for HIP support
 
-*Last updated by Madu Manathunga on 11/21/2022.*
+*Last updated by Andreas Goetz on 04/25/2024.*

--- a/docs/source/hands-on-tutorials.rst
+++ b/docs/source/hands-on-tutorials.rst
@@ -75,7 +75,7 @@ keywords is not relevant.
      ^     ^              ^             ^              ^
      |     |              |             |              |
      |     |              |             |            Compute energy
-     |     |              |             Density matrix cutoff
+     |     |              |             Density matrix convergence threshold
      |     |              Integral cutoff
      |     Basis set
      Hamiltonian
@@ -90,7 +90,7 @@ calculation with the following keyword line.
      ^     ^      ^              ^             ^              ^
      |     |      |              |             |              |
      |     |      |              |             |            Compute energy
-     |     |      |              |             Density matrix cutoff
+     |     |      |              |             Density matrix convergence threshold
      |     |      |              Integral cutoff
      |     |      Basis set
      |     Functional
@@ -106,7 +106,7 @@ specified as follows.
      ^     ^                          ^           ^             ^              ^
      |     |                          |           |             |              |
      |     |                          |           |             |            Compute energy
-     |     |                          |           |           Density matrix cutoff
+     |     |                          |           |           Density matrix convergence threshold
      |     |                          |         Integral cutoff
      |     |                         Basis set
      |     Functional
@@ -122,7 +122,7 @@ follows.
      ^        ^                          ^           ^             ^              ^
      |        |                          |           |             |              |
      |        |                          |           |             |            Compute energy
-     |        |                          |           |             Density matrix cutoff
+     |        |                          |           |             Density matrix convergence threshold
      |        |                          |       Integral cutoff
      |        |                       Basis set
      |        Functionals (Functional_1, Functional_2 separated by a comma)

--- a/docs/source/installation-guide.rst
+++ b/docs/source/installation-guide.rst
@@ -21,7 +21,9 @@ In general QUICK works well with a range of compilers (GNU, Intel), math
 libraries (Intel MKL, reference BLAS/LAPACK, MAGMA), MPI implementations
 (OpenMPI, Intel MPI), and GPU SDK versions (CUDA and ROCm/HIP).  We have
 specifically tested |QUICK_VERSION| with following compilers, libraries, and
-tools under the Linux operating system.
+tools.
+
+**Linux:**
 
  1. GNU GCC v7.3.0; OpenMPI v3.1.1; CUDA v9.2.88; CMake v3.11.4
  2. GNU GCC v8.3.0; OpenMPI v3.1.4; CUDA v10.2.89; CMake v3.15.1
@@ -39,9 +41,11 @@ respective GPU SDKs on supported GPU devices.
 RTX3080Ti, RTX2080Ti, RTX8000, RTX6000, RTX2080, T4, V100, Titan V, P100, M40,
 GTX1080, K80, and K40.
 
-|QUICK_VERSION| HIP version has been tested on the following GPU cards: MI100,
-MI210, and MI250. As of QUICK-23.03, the performance on MI210 and MI250 cards is
-not optimized but the code runs properly. 
+|QUICK_VERSION| HIP version is currently disabled. Please use QUICK-23.08b if you want to use AMD GPUs.
+
+.. |QUICK_VERSION| HIP version has been tested on the following GPU cards: MI100,
+   MI210, and MI250. As of QUICK-23.03, the performance on MI210 and MI250 cards is
+   not optimized but the code runs properly. 
 
 **NOTE:** We recommend that the CUDA/MPI+CUDA and HIP/MPI+HIP versions be
 executed only on dedicated GPU cards where no other tasks are being run.
@@ -50,12 +54,20 @@ and MPI+HIP versions, we also recommend that only one CPU core (MPI task) is
 used per GPU; this can be done by setting the number of processes (*e.g.*, in
 the *mpirun* command) equal to the number of GPUs.
 
-We have also tested |QUICK_VERSION| on Intel-based Macbooks with following
-software stack (compiler installed via Macports):
+**Intel-based Macbooks:**
+
+Software stack (compiler installed via Macports):
 
  1. macOS 11.7.3; GNU/10.4.0, 11.3.0, 12.2.0; OpenMPI 4.1.4
  2. macOS 13.2; GNU 12.2.0, OpenMPI 4.1.4
 
+**ARM-based Macbooks (M3 Pro CPU):**
+
+Software stack (compiler installed via Macports):
+
+ 1. macOS Sonoma 14.4.1; GNU GCC 12.3.0; OpenMPI 4.1.6
+ 2. macOS Sonoma 14.4.1; GNU GCC (Fortran); Clang 17.0.6; OpenMPI 4.1.6
+    
 
 Installation
 ------------
@@ -180,4 +192,4 @@ Uninstallation and Cleaning
 Simply delete contents inside build and install directories and/or delete the
 build and install directories.
 
-*Last updated by Madu Manathunga on 11/21/2022.*
+*Last updated by Andreas Goetz on 04/25/2024.*

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -6,6 +6,8 @@ detected the issues listed below. If you find anything other than these, please
 feel free to report any bugs or issues through our GitHub page:
 `https://github.com/merzlab/QUICK/issues <https://github.com/merzlab/QUICK/issues>`_.
 
+Feel free to ask questions or start a discussion on the Discussions section of our GitHub page: `https://github.com/merzlab/QUICK/discussions <https://github.com/merzlab/QUICK/discussions>`_.
+
 Compile time
 ^^^^^^^^^^^^
 
@@ -13,7 +15,7 @@ Compile time
 ******************************************************************************
 
 NVIDIA has dropped support for sm_30 microarchitecture starting from CUDA
-v11.1, and support for sm_35 amd sm_37 starting from CUDA v12.0.  However,
+v11.1, and support for sm_35 and sm_37 starting from CUDA v12.0.  However,
 QUICK build systems still use sm_30/sm_35/sm_37 flags in NVCC compiler flag
 list for CUDA v11 or higher toolkits if the user specifies Kepler as target
 microarchitecture (i.e. --arch kepler, -DQUICK_USER_ARCH=kepler in legacy and

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -2,10 +2,14 @@ Accuracy and Performance
 ========================
 
 The data reported in this section is solely intended for informative purpose.
-These were obtained using QUICK-21.03. The code is continuously being improved.
+
+These were obtained using QUICK-21.03. The code is continuously being
+improved. QUICK-23.08 is over three times faster than QUICK-20.03 and
+about 2.5 times as fast as QUICK-21.03.
+
 Readers shall not use the data presented here for comparison with other quantum
 chemical codes. If you are interested in doing so, we highly encourage you to
-download the latest QUICK version, compile, and perform your own benchmarks.    
+download the latest QUICK version, compile, and perform your own benchmarks.
 
 
 Accuracy of energies and gradients
@@ -13,8 +17,8 @@ Accuracy of energies and gradients
 
 We have compared energies and gradients computed by QUICK with values computed
 by other quantum chemical packages. HF energies and gradients have displayed
-accuracies up to 1.0E-6 Hartree and 1.0E-4 Hartree/Bohr, respectively, for test
-systems (see `https://github.com/merzlab/QUICK-tests
+accuracies of 1.0E-6 Hartree and 1.0E-4 Hartree/Bohr or better,
+respectively, for test systems (see `https://github.com/merzlab/QUICK-tests
 <https://github.com/merzlab/QUICK-tests>`_ for test cases). DFT energies and
 gradients have shown similar accuracies in most cases, however, we have
 observed larger deviations for some molecular systems. Such deviations usually
@@ -24,8 +28,11 @@ arise due to differences in the exchange correlation quadrature grid.
 Performance of QUICK CUDA serial and MPI parallel versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+**Benchmark data obtained with QUICK-21.03**. The code is continuously
+being improved. **QUICK-23.08 is about 2.5 times faster**.
+
 The following graph gives an idea about the performance for a single point SCF +
-gradient calculation that can be expected with QUICK for a relatively large
+gradient calculation that can be expected with **QUICK-21.03** for a relatively large
 molecule and reasonably sized basis set.  We have used **conservative SCF
 convergence criteria and integral thresholds**.  With these settings, **a
 B3LYP/6-31G\*\* SCF + gradient calculation of valinomycin (168 atoms) takes
@@ -47,7 +54,7 @@ Interface (MPI). In particular for larger calculations the code shows excellent
 scalability, and thus it makes sense to perform calculations with multiple GPUs
 if time-to-solution is of importance.  **A B3LYP/6-31G\*\* single point SCF +
 gradient calculation for the entire Crambin protein (642 atoms) can be
-performed in under 10 minutes** on 16 V100 GPUs.
+performed in under 10 minutes using QUICK-21.03** on 16 V100 GPUs.
 
 .. image:: bench2.png
     :width: 1067px
@@ -62,4 +69,4 @@ Multi-GPU Acceleration into the Quantum Interaction Computational Kernel
 Program, J. Chem. Theory Comput. 2021, 17, 7, 3955–3966.
 <https://pubs.acs.org/doi/abs/10.1021/acs.jctc.1c00145>`_.
 
-*Last updated by Madu Manathunga on 03/03/2022.*
+*Last updated by Andreas Goetz on 04/25/2024.*

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -8,7 +8,7 @@ QUICK-24.03
 • Added ERI engine support for f basis functions to CUDA/MPI+CUDA codes (disabled be default)
 • HIP/MPI+HIP support disabled, please use QUICK version 23.08b for HIP support
 • Added initial Intel OneAPI/LLVM compiler support
-• Added support for the following basis sets: aug-cc-pVTZ, def2-TZVDP, def2-TZVPP, aug-pc-1, pc-2, and aug-pc-2
+• Added support for the following basis sets: aug-cc-pVTZ, def2-TZVPD, def2-TZVPP, aug-pc-1, pc-2, and aug-pc-2
 • Various bug fixes, optimizations, and test updates
 
 QUICK-23.03

--- a/docs/source/user-manual.rst
+++ b/docs/source/user-manual.rst
@@ -4,7 +4,9 @@ User Manual
 QUICK uses a simple text based input file that consists of a line with keywords
 followed by an empty line, the molecular coordinates in xyz format, and
 potentially point charge information after another empty line.  Please see the
-Hands-on Tutorials for details on the input file format. 
+Hands-on Tutorials for details on the input file format.
+
+Feel free to ask questions or start a discussion on the Discussions section of our GitHub page: `https://github.com/merzlab/QUICK/discussions <https://github.com/merzlab/QUICK/discussions>`_.
 
 Units
 ^^^^^
@@ -24,9 +26,13 @@ Keywords for QUICK Input
 
    **HF**   : Hartree-Fock Hamiltonian to be used
 
+   **UHF**  : Unrestricted Hartree-Fock Hamiltonian to be used
+
    **DFT**  : Density Functional Theory to be used.
 
-   NOTE 1 : One Hamiltonian must be selected. There is no default.
+   **UDFT** : Unrestricted Density Functional Theory to be used.
+   
+   NOTE: One Hamiltonian must be selected. There is no default.
 
 
 2. Density Functional Theory
@@ -104,7 +110,7 @@ Grimme type dispersion corrections are requested by adding one of the following 
 
    **DENSERMS=Float** : user defined density matrix maximum RMS for convergence. Default : 1.0E-6.
 
-   **CUTOFF=Float**   : user defined integral cutoff. Default : 1.0E-8.
+   **CUTOFF=Float**   : user defined integral cutoff. Default : 1.0E-7.
 
    **BASISCUTOFF=Float**   : user defined cutoff for neglecting insignificant basis functions. Default : 1.0E-6.
 
@@ -112,23 +118,28 @@ Grimme type dispersion corrections are requested by adding one of the following 
 
    **TIGHTINT**       : use tight cutoffs.  (i.e. DENSERMS=1.0E-7, CUTOFF=1.0E-8, BASISCUTOFF=1.0E-7, XCCUTOFF=1.0E-8)
 
-5. Atomic Charges
-*****************
+5. Charge and Spin Multiplicity
+*******************************
 
-   **CHARGE=Integer**     : A net charge is to be placed on system. Default: 0
+   **CHARGE=Integer** : A net charge is to be placed on system. Default: 0
+
+   **MULT=Integer**   : Spin multiplicity of the system. Default: 1
+
+6. Atomic Charges
+*****************
 
    **EXTCHARGES**     : External charges are included in the system. The point charges must be listed after the molecular Cartesian coordinates in the input file. See the corresponding section in the Hands-on Tutorials of this manual.
 
    **DIPOLE**       : Write dipole moments, Mulliken and Löwdin charges into the output file.
 
-6. Gradient Calculation
+7. Gradient Calculation
 ***********************
 
    **GRADIENT**         : Calculates analytical gradients.
 
    **GRADCUTOFF=Float** : user defined cutoff for gradients. Default : 1.0E-7 (automatically set to 1.0E-6 or 1.0E-8 if COARSEINT or TIGHTINT keyword is specified) 
 
-7. Geometry Optimization
+8. Geometry Optimization
 ************************
 
    **OPTIMIZE=Integer** : Performs a geometry optimization with a maximum of *Integer* steps. Default: 3 x Number of atoms.
@@ -137,7 +148,7 @@ Grimme type dispersion corrections are requested by adding one of the following 
 
    **LOPT**             : Use legacy QUICK optimizer instead of DL-FIND.
 
-   **GTOL**             : User defined maximum RMS value of the gradient vector. Default: 4.5E-4  
+   **GTOL**             : User defined maximum RMS value of the gradient vector. Default: 4.5E-4 (using tighter convergence criteria may require tightening SCF convergence, see TIGHTINT keyword)
 
    **ETOL**             : User defined maximum energy change between two consecutive optimization cycles. Default: 1.0E-6
 
@@ -149,9 +160,9 @@ If you are using the DL-FIND optimizer in your work, please make sure to cite th
 
    `Johannes Kästner, Joanne M. Carr, Thomas W. Keal, Walter Thiel, Adrian Wander, and Paul Sherwood, DL-FIND: An Open-Source Geometry Optimizer for Atomistic Simulations, J. Phys. Chem. A, 2009, 113 (43), 11856-11865. <https://pubs.acs.org/doi/10.1021/jp9028968>`_.
 
-8. Data Exporting
+9. Data Exporting
 *****************
 
    **EXPORT=MOLDEN** : Generates a molden file that contains orbitals, charges, geometries, etc. 
 
-*Last updated by Andy Goetz on 02/17/2023.*
+*Last updated by Andy Goetz on 04/25/2024.*


### PR DESCRIPTION
Updates for QUICK-24.03

Benchmarks will need updating in the future. For now I point out that these are old benchmarks and the current version is about 2.5x faster.